### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pynacl
+flask


### PR DESCRIPTION
On some systems, the flask module is not installed by default, so this allows pip3 to install this straightaway from the requirements.txt file.